### PR TITLE
attach .key to .data, so errors have err.data.key

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ function multidrive (store, createArchive, closeArchive, cb) {
   function sink (err, data) {
     if (err) return cb(err)
     var values = Object.keys(data).map(function (key) {
-      return JSON.parse(data[key])
+      var value = JSON.parse(data[key])
+      value.key = key
+      return value
     })
     debug('found %s dats', values.length)
 

--- a/test.js
+++ b/test.js
@@ -152,7 +152,7 @@ test('drive.list', function (t) {
   })
 
   t.test('should not fail on initial archive creation errors', function (t) {
-    t.plan(6)
+    t.plan(7)
     flushToilet()
 
     var store = toilet('state.json')
@@ -174,7 +174,8 @@ test('drive.list', function (t) {
           var drives = drive.list()
           t.equal(drives.length, 1, 'one drive')
           t.ok(drives[0] instanceof Error)
-          t.deepEqual(drives[0].data, { some: 'data' })
+          t.equal(drives[0].data.some, 'data')
+          t.equal(drives[0].data.key, archive.key.toString('hex'))
         })
       })
     })


### PR DESCRIPTION
this helps dealing with `dat instance of Error` archives