### PR TITLE
Added disconnect method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ If an archive with the same key already exists, returns that instead and sets
 ### drive.close(key, callback(err))
 Remove an archive by its public key. Calls `closeArchive()`
 
+### drive.disconnect(callback(err))
+Disconnects the drive from the store and closes all archives (without removing them).
+
 ## Installation
 ```sh
 $ npm install multidrive

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Create a new multidrive instance. `db` should be a valid `toiletdb` instance.
 `createArchive` has an api of `createArchive(data, done)` where `data` is passed in
 by `drive.create()` and `done(err, archive)` expects a valid archive.
 
+`closeArchive` has an api of `closeArchive(archive, done)` where `archive` was
+created by `createArchive` and `done(err)` is expected to be called when the
+archive has been properly closed. `closeArchive` is called when a specific
+archive is closed through `.close` or when through `.disconnect` all archives get
+disconnected.
+
 ### archives = drive.list()
 List all `archives` in the `multidrive`.
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function multidrive (store, createArchive, closeArchive, cb) {
   }
 
   function create (data, cb) {
-    if (_disconnected) return cb(new Error('disconnected'))
+    if (_disconnected) return setImmediate(cb.bind(null, new Error('disconnected')))
     debug('create archive data=%j', data)
     createArchive(data, function (err, archive) {
       if (err) return cb(err)
@@ -92,10 +92,10 @@ function multidrive (store, createArchive, closeArchive, cb) {
   }
 
   function disconnect (cb) {
-    if (_disconnected) return cb(new Error('disconnected'))
+    if (_disconnected) return setImmediate(cb.bind(null, new Error('disconnected')))
     _disconnected = true
     store = null
-    if (archives.length === 0) return cb()
+    if (archives.length === 0) return setImmediate(cb)
     var _archives = archives
     var count = _archives.length
     var _err
@@ -116,7 +116,7 @@ function multidrive (store, createArchive, closeArchive, cb) {
   }
 
   function close (key, cb) {
-    if (_disconnected) return cb(new Error('disconnected'))
+    if (_disconnected) return setImmediate(cb.bind(null, new Error('disconnected')))
     if (Buffer.isBuffer(key)) key = key.toString('hex')
     debug('close archive key=%s', key)
     var i = 0
@@ -126,7 +126,7 @@ function multidrive (store, createArchive, closeArchive, cb) {
       i = j
       return true
     })
-    if (!archive) return cb(new Error('could not find archive ' + key))
+    if (!archive) return setImmediate(cb.bind(null, new Error('could not find archive ' + key)))
     if (archive instanceof Error) next()
     else closeArchive(archive, next)
 

--- a/index.js
+++ b/index.js
@@ -11,10 +11,12 @@ function multidrive (store, createArchive, closeArchive, cb) {
   assert.equal(typeof cb, 'function', 'multidrive: cb should be type function')
 
   var archives = []
+  var _disconnected = false
   var drive = {
     list: list,
     create: create,
-    close: close
+    close: close,
+    disconnect: disconnect
   }
 
   debug('initialize')
@@ -58,6 +60,7 @@ function multidrive (store, createArchive, closeArchive, cb) {
   }
 
   function create (data, cb) {
+    if (_disconnected) return cb(new Error('disconnected'))
     debug('create archive data=%j', data)
     createArchive(data, function (err, archive) {
       if (err) return cb(err)
@@ -88,7 +91,32 @@ function multidrive (store, createArchive, closeArchive, cb) {
     })
   }
 
+  function disconnect (cb) {
+    if (_disconnected) return cb(new Error('disconnected'))
+    _disconnected = true
+    store = null
+    if (archives.length === 0) return cb()
+    var _archives = archives
+    var count = _archives.length
+    var _err
+    _archives.forEach(function (archive) {
+      closeArchive(archive, next)
+    })
+    archives = []
+
+    function next (err) {
+      count--
+      if (err && !_err) {
+        _err = err
+      }
+      if (count === 0) {
+        cb(_err)
+      }
+    }
+  }
+
   function close (key, cb) {
+    if (_disconnected) return cb(new Error('disconnected'))
     if (Buffer.isBuffer(key)) key = key.toString('hex')
     debug('close archive key=%s', key)
     var i = 0

--- a/test.js
+++ b/test.js
@@ -13,6 +13,9 @@ function flushToilet () {
 flushToilet()
 
 var noop = function () {}
+var noopCb = function () {
+  setImmediate(arguments[arguments.length - 1])
+}
 var multidrive = require('./')
 
 test('drive = multidrive', function (t) {
@@ -22,20 +25,24 @@ test('drive = multidrive', function (t) {
     t.throws(multidrive.bind(null, {}), /function/)
     t.throws(multidrive.bind(null, {}, noop), /function/)
   })
+  t.end()
 })
 
 test('drive.create', function (t) {
   t.test('should create an archive', function (t) {
-    t.plan(5)
+    t.plan(6)
 
     var store = toilet('state.json')
-    multidrive(store, createArchive, noop, function (err, drive) {
+    multidrive(store, createArchive, noopCb, function (err, drive) {
       t.ifError(err, 'no err')
       t.equal(typeof drive, 'object', 'drive was returned')
       drive.create(null, function (err, archive) {
         t.ifError(err, 'no err')
         t.equal(typeof archive, 'object', 'archive was created')
         t.ok(Buffer.isBuffer(archive.metadata.key), 'archive has a key')
+        drive.disconnect(function (err) {
+          t.error(err)
+        })
       })
     })
 
@@ -48,20 +55,26 @@ test('drive.create', function (t) {
   })
 
   t.test('should recreate archives', function (t) {
-    t.plan(4)
+    t.plan(6)
     flushToilet()
     var store = toilet('state.json')
-    multidrive(store, createArchive, noop, function (err, drive) {
+    multidrive(store, createArchive, noopCb, function (err, drive) {
       t.ifError(err, 'no err')
 
       drive.create({ hello: 'world' }, function (err, archive) {
         t.ifError(err, 'no err')
 
-        var newStore = toilet('state.json')
-        multidrive(newStore, createArchive, noop, function (err, drive) {
-          t.ifError(err, 'no err')
-          var drives = drive.list()
-          t.equal(drives.length, 1, 'one drive on init')
+        drive.disconnect(function (err) {
+          t.error(err)
+          var newStore = toilet('state.json')
+          multidrive(newStore, createArchive, noopCb, function (err, drive) {
+            t.ifError(err, 'no err')
+            var drives = drive.list()
+            t.equal(drives.length, 1, 'one drive on init')
+            drive.disconnect(function (err) {
+              t.error(err)
+            })
+          })
         })
       })
     })
@@ -75,12 +88,12 @@ test('drive.create', function (t) {
   })
 
   t.test('should noop on duplicates', function (t) {
-    t.plan(5)
+    t.plan(6)
     flushToilet()
     var store = toilet('state.json')
     var db = memdb()
     var drive = hyperdrive(db)
-    multidrive(store, createArchive, noop, function (err, drive) {
+    multidrive(store, createArchive, noopCb, function (err, drive) {
       t.ifError(err, 'no err')
 
       drive.create({ hello: 'world' }, function (err, archive) {
@@ -90,6 +103,9 @@ test('drive.create', function (t) {
           t.ifError(err, 'no err')
           t.equal(_archive, archive)
           t.equal(duplicate, true)
+        })
+        drive.disconnect(function (err) {
+          t.error(err)
         })
       })
     })
@@ -101,12 +117,12 @@ test('drive.create', function (t) {
   })
 
   t.test('should properly compare different key types', function (t) {
-    t.plan(5)
+    t.plan(6)
     flushToilet()
     var store = toilet('state.json')
     var db = memdb()
     var drive = hyperdrive(db)
-    multidrive(store, createArchive, noop, function (err, drive) {
+    multidrive(store, createArchive, noopCb, function (err, drive) {
       t.ifError(err, 'no err')
 
       drive.create({ hello: 'world' }, function (err, archive) {
@@ -116,6 +132,9 @@ test('drive.create', function (t) {
           t.ifError(err, 'no err')
           t.equal(_archive, archive)
           t.equal(duplicate, true)
+          drive.disconnect(function (err) {
+            t.error(err)
+          })
         })
       })
     })
@@ -126,20 +145,24 @@ test('drive.create', function (t) {
       done(null, archive)
     }
   })
+  t.end()
 })
 
 test('drive.list', function (t) {
   t.test('should list archives', function (t) {
-    t.plan(3)
+    t.plan(4)
     flushToilet()
 
     var store = toilet('state.json')
-    multidrive(store, createArchive, noop, function (err, drive) {
+    multidrive(store, createArchive, noopCb, function (err, drive) {
       t.ifError(err, 'no err')
       drive.create(null, function (err, archive) {
         t.ifError(err, 'no err')
         var drives = drive.list()
         t.equal(drives.length, 1, 'one drive')
+        drive.disconnect(function (err) {
+          t.error(err)
+        })
       })
     })
 
@@ -152,7 +175,7 @@ test('drive.list', function (t) {
   })
 
   t.test('should not fail on initial archive creation errors', function (t) {
-    t.plan(7)
+    t.plan(9)
     flushToilet()
 
     var store = toilet('state.json')
@@ -162,29 +185,36 @@ test('drive.list', function (t) {
       var archive = drive.createArchive()
       done(null, archive)
     }
-    multidrive(store, createArchive, noop, function (err, drive) {
+    multidrive(store, createArchive, noopCb, function (err, drive) {
       t.ifError(err, 'no err')
       drive.create({ some: 'data' }, function (err, archive) {
         t.ifError(err, 'no err')
         var createArchive = function (data, done) {
           done(Error('not today'))
         }
-        multidrive(store, createArchive, noop, function (err, drive) {
-          t.ifError(err, 'no err')
-          var drives = drive.list()
-          t.equal(drives.length, 1, 'one drive')
-          t.ok(drives[0] instanceof Error)
-          t.equal(drives[0].data.some, 'data')
-          t.equal(drives[0].data.key, archive.key.toString('hex'))
+        drive.disconnect(function (err) {
+          t.error(err)
+          multidrive(store, createArchive, noopCb, function (err, drive) {
+            t.ifError(err, 'no err')
+            var drives = drive.list()
+            t.equal(drives.length, 1, 'one drive')
+            t.ok(drives[0] instanceof Error)
+            t.equal(drives[0].data.some, 'data')
+            t.equal(drives[0].data.key, archive.key.toString('hex'))
+            drive.disconnect(function (err) {
+              t.error(err)
+            })
+          })
         })
       })
     })
   })
+  t.end()
 })
 
 test('drive.close', function (t) {
   t.test('close an archive', function (t) {
-    t.plan(4)
+    t.plan(5)
     flushToilet()
 
     var store = toilet('state.json')
@@ -196,6 +226,9 @@ test('drive.close', function (t) {
           t.ifError(err, 'no err')
           var drives = drive.list()
           t.equal(drives.length, 0, 'no drives left')
+          drive.disconnect(function (err) {
+            t.error(err)
+          })
         })
       })
     })
@@ -214,7 +247,7 @@ test('drive.close', function (t) {
   })
 
   t.test('close an archive instanceof Error', function (t) {
-    t.plan(5)
+    t.plan(7)
     flushToilet()
 
     var store = toilet('state.json')
@@ -225,13 +258,19 @@ test('drive.close', function (t) {
         var createArchive = function (data, done) {
           done(Error('not today'))
         }
-        multidrive(store, createArchive, noop, function (err, drive) {
-          t.ifError(err, 'no err')
-          var errDat = drive.list()[0]
-          drive.close(errDat.data.key, function (err) {
+        drive.disconnect(function (err) {
+          t.error(err)
+          multidrive(store, createArchive, noopCb, function (err, drive) {
             t.ifError(err, 'no err')
-            var drives = drive.list()
-            t.equal(drives.length, 0, 'no drives left')
+            var errDat = drive.list()[0]
+            drive.close(errDat.data.key, function (err) {
+              t.ifError(err, 'no err')
+              var drives = drive.list()
+              t.equal(drives.length, 0, 'no drives left')
+              drive.disconnect(function (err) {
+                t.error(err)
+              })
+            })
           })
         })
       })
@@ -247,6 +286,91 @@ test('drive.close', function (t) {
     function closeArchive (archive, done) {
       archive.close()
       done()
+    }
+  })
+  t.end()
+})
+
+test('drive.disconnect', function (t) {
+  t.test('create and disconnect without archives created', function (t) {
+    t.plan(2)
+    flushToilet()
+    var store = toilet('state.json')
+    multidrive(store, noop, noop, function (err, drive) {
+      t.error(err)
+      drive.disconnect(function (err) {
+        t.error(err)
+      })
+    })
+  })
+  t.test('errors after disconnection', function (t) {
+    t.plan(6)
+    flushToilet()
+    var store = toilet('state.json')
+    multidrive(store, noop, noop, function (err, drive) {
+      t.error(err)
+      drive.disconnect(function (err) {
+        t.error(err)
+        t.equals(drive.list().length, 0)
+        drive.create(null, function (err) {
+          t.equals(err.message, 'disconnected')
+          drive.close(null, function (err) {
+            t.equals(err.message, 'disconnected')
+            drive.disconnect(function (err) {
+              t.equals(err.message, 'disconnected')
+            })
+          })
+        })
+      })
+    })
+  })
+  t.test('disconnecting closes archives', function (t) {
+    t.plan(4)
+    flushToilet()
+    var store = toilet('state.json')
+    multidrive(store, createArchive, closeArchive, function (err, drive) {
+      t.error(err)
+      drive.create(null, function (err, archive) {
+        t.error(err)
+        drive.disconnect(function (err) {
+          t.error(err)
+          t.ok(archive._closed)
+        })
+      })
+    })
+
+    function createArchive (data, done) {
+      var db = memdb()
+      var drive = hyperdrive(db)
+      var archive = drive.createArchive()
+      done(null, archive)
+    }
+
+    function closeArchive (archive, done) {
+      archive.close()
+      done()
+    }
+  })
+  t.test('disconnecting closes archives and passes through errors', function (t) {
+    t.plan(3)
+    flushToilet()
+    var store = toilet('state.json')
+    multidrive(store, createArchive, closeArchive, function (err, drive) {
+      t.error(err)
+      drive.create({key: 'x'}, function (err, archive) {
+        t.error(err)
+        drive.disconnect(function (err) {
+          t.equals(err.message, 'test-error')
+        })
+      })
+    })
+
+    function createArchive (data, done) {
+      done(null, data)
+    }
+
+    function closeArchive (archive, done) {
+      done(new Error('test-error'))
     }
   })
   t.end()


### PR DESCRIPTION
In order to properly shut down hyperdrives _(Ctrl+C)_ it is good to have a disconnect method that disconnects all the archives (and networks) for a clean closing of an application. _(Note: this is also quite useful for clean unit tests)_